### PR TITLE
CN-8974: Bump GitHub Action dependencies to latest versions

### DIFF
--- a/.github/actions/dependency-check/action.yml
+++ b/.github/actions/dependency-check/action.yml
@@ -7,12 +7,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v4.7.1
+    - uses: actions/setup-java@v5
       with:
         distribution: corretto
         java-version: 21
         cache: maven
-    - uses: stCarolas/setup-maven@v5
+    - uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.8.5
     - name: Build

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Notify Slack Finished
-      uses: slackapi/slack-github-action@v2.1.1
+      uses: slackapi/slack-github-action@v4
       with:
         payload: |
           { "attachments": [

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -9,21 +9,21 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v4.7.1
+    - uses: actions/setup-java@v5
       with:
         distribution: corretto
         java-version: 21
         cache: maven
-    - uses: stCarolas/setup-maven@v5
+    - uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.8.5
-    - uses: KengoTODA/actions-setup-docker-compose@main
+    - uses: KengoTODA/actions-setup-docker-compose@v1.2.4
       with:
         version: '1.29.2'
     - name: Run Tests
       shell: bash
       run: mvn --fail-fast clean test
-    - uses: mikepenz/action-junit-report@v5.6.2
+    - uses: mikepenz/action-junit-report@v6
       if: always()
       with:
         report_paths: '**/surefire-reports/TEST-*.xml'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -14,7 +14,7 @@ jobs:
   DependencyCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - id: dependency-check
         uses: ./.github/actions/dependency-check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - run: git checkout ${{ needs.setup.outputs.version }}


### PR DESCRIPTION
# CN-8974

**What:**

Bump every outdated GitHub Action import to its latest release.

**How:**

- `actions/checkout` v4 → v7
- `actions/setup-java` v4.7.1 → v5
- `stCarolas/setup-maven` v5 → v5.1
- `mikepenz/action-junit-report` v5.6.2 → v6
- `slackapi/slack-github-action` v2.1.1 → v4
- `KengoTODA/actions-setup-docker-compose` — pin floating `main` to v1.2.4

Breaking changes checked against our usage:

- Most majors are Node 24 runtime bumps, fine on GitHub-hosted runners.
- `slack-github-action` v4 parses multiline YAML payloads more strictly — our payload is a properly indented block scalar and keeps the same `webhook`/`webhook-type` API, unaffected.
- backend already runs setup-java v5 and junit-report v6 with the same inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)